### PR TITLE
Updated ESlint dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "vary": "~1.1.2"
   },
   "devDependencies": {
-    "eslint": "4.19.1",
-    "eslint-config-standard": "11.0.0",
-    "eslint-plugin-import": "2.13.0",
-    "eslint-plugin-markdown": "1.0.0-beta.6",
-    "eslint-plugin-node": "6.0.1",
-    "eslint-plugin-promise": "3.8.0",
+    "eslint": "^8.57.1",
+    "eslint-config-standard": "17.1",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-markdown": "^5.1.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-standard": "3.1.0",
     "istanbul": "0.4.5",
     "mocha": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "eslint-plugin-markdown": "^5.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.6.0",
-    "eslint-plugin-standard": "3.1.0",
     "istanbul": "0.4.5",
     "mocha": "3.5.3",
     "supertest": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "eslint": "^8.57.1",
-    "eslint-config-standard": "17.1",
+    "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-markdown": "^5.1.0",
     "eslint-plugin-node": "^11.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-
 var http = require('http')
 var methodOverride = require('..')
 var request = require('supertest')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->
1. Updated the following dev dependencies below
a.  eslint `4.19.1` to `8.57.1`
b. eslint-config-standard `11.0.0` to `17.1.0`
c. eslint-plugin-import `2.13.0` to `2.32.0`
d. eslint-plugin-markdown `1.0.0-beta.6` to `5.1.0`
e. eslint-plugin-node `6.0.1` to `11.1.0`
f. eslint-plugin-promise `3.8.0` to `6.6.0`
2. Removed deprecated `eslint-plugin-standard` because `eslint-config-standard` [does not require it](https://github.com/standard/standard/issues/1316) anymore from `16.0.0` and later.
3. Removed a blank line at the start of `test.js` after the updated dependencies above caught it.
4. However, when running `npm run lint`, warnings and errors will appear respectively mainly because of the `no-var` rule and parsing errors coming from markdowns. These were not present prior to updating the dependencies. Should be ok to merge this request.
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
